### PR TITLE
Reduce numpy version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy>=2.0.1",
+    "numpy>=1.8",
     "scipy>=1.14.0",
     "matplotlib>=3.9.1",
     "six>=1.16.0",
@@ -40,14 +40,12 @@ docs = [
     "nbsphinx-link>=1.3.0",
     "jupyter>=1.0.0",
 ]
-test = [
-    "pytest>=8.3.2",
-]
 
 [tool.flit.sdist]
 include = ["tests/"]
 
 [tool.rye]
+universal = true
 dev-dependencies = [
     "ruff>=0.5.5",
     "pytest>=8.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "flit_core.buildapi"
 name = "acoustic-toolbox"
 version = "0.1.1"
 authors = [
-    { name = "Valentin LE BESCOND", email = "valentin.lebescond@univ-eiffel.fr" }
+    { name = "Valentin LE BESCOND", email = "valentin.lebescond@univ-eiffel.fr" },
+    { name = "Andrew Mitchell", email = "a.j.mitchell@ucl.ac.uk"}
 ]
 description = "Acoustic Toolbox module for Python."
 readme = "README.md"
@@ -16,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy>=1.8",
+    "numpy>=1.23.5",
     "scipy>=1.14.0",
     "matplotlib>=3.9.1",
     "six>=1.16.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -196,7 +196,7 @@ notebook==7.2.1
 notebook-shim==0.2.4
     # via jupyterlab
     # via notebook
-numpy==1.26.4
+numpy==2.0.1
     # via acoustic-toolbox
     # via contourpy
     # via matplotlib

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,66 +4,392 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
-#   generate-hashes: false
-#   universal: false
 
 -e file:.
+alabaster==0.7.16
+    # via sphinx
+anyio==4.4.0
+    # via httpx
+    # via jupyter-server
+appnope==0.1.4
+    # via ipykernel
+argon2-cffi==23.1.0
+    # via jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
+arrow==1.3.0
+    # via isoduration
+asttokens==2.4.1
+    # via stack-data
+async-lru==2.0.4
+    # via jupyterlab
+attrs==23.2.0
+    # via jsonschema
+    # via referencing
+babel==2.15.0
+    # via jupyterlab-server
+    # via sphinx
+beautifulsoup4==4.12.3
+    # via nbconvert
+bleach==6.1.0
+    # via nbconvert
+certifi==2024.7.4
+    # via httpcore
+    # via httpx
+    # via requests
 cffi==1.16.0
+    # via argon2-cffi-bindings
     # via pysoundfile
-colorama==0.4.6
-    # via pytest
+charset-normalizer==3.3.2
+    # via requests
+comm==0.2.2
+    # via ipykernel
+    # via ipywidgets
 contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
+debugpy==1.8.2
+    # via ipykernel
+decorator==5.1.1
+    # via ipython
+defusedxml==0.7.1
+    # via nbconvert
+docutils==0.18.1
+    # via nbsphinx
+    # via sphinx
+    # via sphinx-rtd-theme
 exceptiongroup==1.2.2
+    # via anyio
+    # via ipython
     # via pytest
+executing==2.0.1
+    # via stack-data
+fastjsonschema==2.20.0
+    # via nbformat
 fonttools==4.53.1
     # via matplotlib
+fqdn==1.5.1
+    # via jsonschema
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.5
+    # via httpx
+httpx==0.27.0
+    # via jupyterlab
+idna==3.7
+    # via anyio
+    # via httpx
+    # via jsonschema
+    # via requests
+imagesize==1.4.1
+    # via sphinx
 iniconfig==2.0.0
     # via pytest
+ipykernel==6.29.5
+    # via jupyter
+    # via jupyter-console
+    # via jupyterlab
+    # via qtconsole
+ipython==8.26.0
+    # via ipykernel
+    # via ipywidgets
+    # via jupyter-console
+ipywidgets==8.1.3
+    # via jupyter
+isoduration==20.11.0
+    # via jsonschema
+jedi==0.19.1
+    # via ipython
+jinja2==3.1.4
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
+    # via nbconvert
+    # via nbsphinx
+    # via sphinx
+json5==0.9.25
+    # via jupyterlab-server
+jsonpointer==3.0.0
+    # via jsonschema
+jsonschema==4.23.0
+    # via jupyter-events
+    # via jupyterlab-server
+    # via nbformat
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+jupyter==1.0.0
+    # via acoustic-toolbox
+jupyter-client==8.6.2
+    # via ipykernel
+    # via jupyter-console
+    # via jupyter-server
+    # via nbclient
+    # via qtconsole
+jupyter-console==6.6.3
+    # via jupyter
+jupyter-core==5.7.2
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-server
+    # via jupyterlab
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+    # via qtconsole
+jupyter-events==0.10.0
+    # via jupyter-server
+jupyter-lsp==2.2.5
+    # via jupyterlab
+jupyter-server==2.14.2
+    # via jupyter-lsp
+    # via jupyterlab
+    # via jupyterlab-server
+    # via notebook
+    # via notebook-shim
+jupyter-server-terminals==0.5.3
+    # via jupyter-server
+jupyterlab==4.2.4
+    # via notebook
+jupyterlab-pygments==0.3.0
+    # via nbconvert
+jupyterlab-server==2.27.3
+    # via jupyterlab
+    # via notebook
+jupyterlab-widgets==3.0.11
+    # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
+markupsafe==2.1.5
+    # via jinja2
+    # via nbconvert
 matplotlib==3.9.1
     # via acoustic-toolbox
-numpy==2.0.1
+matplotlib-inline==0.1.7
+    # via ipykernel
+    # via ipython
+mistune==3.0.2
+    # via nbconvert
+nbclient==0.10.0
+    # via nbconvert
+nbconvert==7.16.4
+    # via jupyter
+    # via jupyter-server
+    # via nbsphinx
+nbformat==5.10.4
+    # via jupyter-server
+    # via nbclient
+    # via nbconvert
+    # via nbsphinx
+nbsphinx==0.9.4
+    # via acoustic-toolbox
+    # via nbsphinx-link
+nbsphinx-link==1.3.0
+    # via acoustic-toolbox
+nest-asyncio==1.6.0
+    # via ipykernel
+notebook==7.2.1
+    # via jupyter
+notebook-shim==0.2.4
+    # via jupyterlab
+    # via notebook
+numpy==1.26.4
     # via acoustic-toolbox
     # via contourpy
     # via matplotlib
     # via pandas
     # via scipy
+overrides==7.7.0
+    # via jupyter-server
 packaging==24.1
+    # via ipykernel
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
     # via matplotlib
+    # via nbconvert
     # via pytest
+    # via qtconsole
+    # via qtpy
+    # via sphinx
 pandas==2.2.2
     # via acoustic-toolbox
+pandocfilters==1.5.1
+    # via nbconvert
+parso==0.8.4
+    # via jedi
+pexpect==4.9.0
+    # via ipython
 pillow==10.4.0
     # via matplotlib
+platformdirs==4.2.2
+    # via jupyter-core
 pluggy==1.5.0
     # via pytest
+prometheus-client==0.20.0
+    # via jupyter-server
+prompt-toolkit==3.0.47
+    # via ipython
+    # via jupyter-console
+psutil==6.0.0
+    # via ipykernel
+ptyprocess==0.7.0
+    # via pexpect
+    # via terminado
+pure-eval==0.2.3
+    # via stack-data
 pycparser==2.22
     # via cffi
+pygments==2.18.0
+    # via ipython
+    # via jupyter-console
+    # via nbconvert
+    # via qtconsole
+    # via sphinx
 pyparsing==3.1.2
     # via matplotlib
 pysoundfile==0.9.0.post1
     # via acoustic-toolbox
 pytest==8.3.2
 python-dateutil==2.9.0.post0
+    # via arrow
+    # via jupyter-client
     # via matplotlib
     # via pandas
+python-json-logger==2.0.7
+    # via jupyter-events
 pytz==2024.1
     # via pandas
+pyyaml==6.0.1
+    # via jupyter-events
+pyzmq==26.0.3
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-server
+    # via qtconsole
+qtconsole==5.5.2
+    # via jupyter
+qtpy==2.4.1
+    # via qtconsole
+referencing==0.35.1
+    # via jsonschema
+    # via jsonschema-specifications
+    # via jupyter-events
+requests==2.32.3
+    # via jupyterlab-server
+    # via sphinx
+rfc3339-validator==0.1.4
+    # via jsonschema
+    # via jupyter-events
+rfc3986-validator==0.1.1
+    # via jsonschema
+    # via jupyter-events
+rpds-py==0.19.1
+    # via jsonschema
+    # via referencing
 ruff==0.5.5
 scipy==1.14.0
     # via acoustic-toolbox
+send2trash==1.8.3
+    # via jupyter-server
+setuptools==72.1.0
+    # via jupyterlab
 six==1.16.0
     # via acoustic-toolbox
+    # via asttokens
+    # via bleach
     # via python-dateutil
+    # via rfc3339-validator
+sniffio==1.3.1
+    # via anyio
+    # via httpx
+snowballstemmer==2.2.0
+    # via sphinx
+soupsieve==2.5
+    # via beautifulsoup4
+sphinx==7.3.7
+    # via acoustic-toolbox
+    # via nbsphinx
+    # via nbsphinx-link
+    # via sphinx-rtd-theme
+    # via sphinxcontrib-jquery
+sphinx-rtd-theme==1.3.0rc1
+    # via acoustic-toolbox
+sphinxcontrib-applehelp==2.0.0
+    # via sphinx
+sphinxcontrib-devhelp==2.0.0
+    # via sphinx
+sphinxcontrib-htmlhelp==2.1.0
+    # via sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==2.0.0
+    # via sphinx
+sphinxcontrib-serializinghtml==2.0.0
+    # via sphinx
+stack-data==0.6.3
+    # via ipython
 tabulate==0.9.0
     # via acoustic-toolbox
+terminado==0.18.1
+    # via jupyter-server
+    # via jupyter-server-terminals
+tinycss2==1.3.0
+    # via nbconvert
 tomli==2.0.1
+    # via jupyterlab
     # via pytest
+    # via sphinx
+tornado==6.4.1
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-server
+    # via jupyterlab
+    # via notebook
+    # via terminado
+traitlets==5.14.3
+    # via comm
+    # via ipykernel
+    # via ipython
+    # via ipywidgets
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-core
+    # via jupyter-events
+    # via jupyter-server
+    # via jupyterlab
+    # via matplotlib-inline
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+    # via nbsphinx
+    # via qtconsole
+types-python-dateutil==2.9.0.20240316
+    # via arrow
+typing-extensions==4.12.2
+    # via anyio
+    # via async-lru
+    # via ipython
 tzdata==2024.1
     # via pandas
+uri-template==1.3.0
+    # via jsonschema
+urllib3==2.2.2
+    # via requests
+wcwidth==0.2.13
+    # via prompt-toolkit
+webcolors==24.6.0
+    # via jsonschema
+webencodings==0.5.1
+    # via bleach
+    # via tinycss2
+websocket-client==1.8.0
+    # via jupyter-server
+widgetsnbextension==4.0.11
+    # via ipywidgets

--- a/requirements.lock
+++ b/requirements.lock
@@ -193,7 +193,7 @@ notebook==7.2.1
 notebook-shim==0.2.4
     # via jupyterlab
     # via notebook
-numpy==1.26.4
+numpy==2.0.1
     # via acoustic-toolbox
     # via contourpy
     # via matplotlib

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,53 +4,383 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
-#   generate-hashes: false
-#   universal: false
 
 -e file:.
+alabaster==0.7.16
+    # via sphinx
+anyio==4.4.0
+    # via httpx
+    # via jupyter-server
+appnope==0.1.4
+    # via ipykernel
+argon2-cffi==23.1.0
+    # via jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
+arrow==1.3.0
+    # via isoduration
+asttokens==2.4.1
+    # via stack-data
+async-lru==2.0.4
+    # via jupyterlab
+attrs==23.2.0
+    # via jsonschema
+    # via referencing
+babel==2.15.0
+    # via jupyterlab-server
+    # via sphinx
+beautifulsoup4==4.12.3
+    # via nbconvert
+bleach==6.1.0
+    # via nbconvert
+certifi==2024.7.4
+    # via httpcore
+    # via httpx
+    # via requests
 cffi==1.16.0
+    # via argon2-cffi-bindings
     # via pysoundfile
+charset-normalizer==3.3.2
+    # via requests
+comm==0.2.2
+    # via ipykernel
+    # via ipywidgets
 contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
+debugpy==1.8.2
+    # via ipykernel
+decorator==5.1.1
+    # via ipython
+defusedxml==0.7.1
+    # via nbconvert
+docutils==0.18.1
+    # via nbsphinx
+    # via sphinx
+    # via sphinx-rtd-theme
+exceptiongroup==1.2.2
+    # via anyio
+    # via ipython
+executing==2.0.1
+    # via stack-data
+fastjsonschema==2.20.0
+    # via nbformat
 fonttools==4.53.1
     # via matplotlib
+fqdn==1.5.1
+    # via jsonschema
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.5
+    # via httpx
+httpx==0.27.0
+    # via jupyterlab
+idna==3.7
+    # via anyio
+    # via httpx
+    # via jsonschema
+    # via requests
+imagesize==1.4.1
+    # via sphinx
+ipykernel==6.29.5
+    # via jupyter
+    # via jupyter-console
+    # via jupyterlab
+    # via qtconsole
+ipython==8.26.0
+    # via ipykernel
+    # via ipywidgets
+    # via jupyter-console
+ipywidgets==8.1.3
+    # via jupyter
+isoduration==20.11.0
+    # via jsonschema
+jedi==0.19.1
+    # via ipython
+jinja2==3.1.4
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
+    # via nbconvert
+    # via nbsphinx
+    # via sphinx
+json5==0.9.25
+    # via jupyterlab-server
+jsonpointer==3.0.0
+    # via jsonschema
+jsonschema==4.23.0
+    # via jupyter-events
+    # via jupyterlab-server
+    # via nbformat
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+jupyter==1.0.0
+    # via acoustic-toolbox
+jupyter-client==8.6.2
+    # via ipykernel
+    # via jupyter-console
+    # via jupyter-server
+    # via nbclient
+    # via qtconsole
+jupyter-console==6.6.3
+    # via jupyter
+jupyter-core==5.7.2
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-server
+    # via jupyterlab
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+    # via qtconsole
+jupyter-events==0.10.0
+    # via jupyter-server
+jupyter-lsp==2.2.5
+    # via jupyterlab
+jupyter-server==2.14.2
+    # via jupyter-lsp
+    # via jupyterlab
+    # via jupyterlab-server
+    # via notebook
+    # via notebook-shim
+jupyter-server-terminals==0.5.3
+    # via jupyter-server
+jupyterlab==4.2.4
+    # via notebook
+jupyterlab-pygments==0.3.0
+    # via nbconvert
+jupyterlab-server==2.27.3
+    # via jupyterlab
+    # via notebook
+jupyterlab-widgets==3.0.11
+    # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
+markupsafe==2.1.5
+    # via jinja2
+    # via nbconvert
 matplotlib==3.9.1
     # via acoustic-toolbox
-numpy==2.0.1
+matplotlib-inline==0.1.7
+    # via ipykernel
+    # via ipython
+mistune==3.0.2
+    # via nbconvert
+nbclient==0.10.0
+    # via nbconvert
+nbconvert==7.16.4
+    # via jupyter
+    # via jupyter-server
+    # via nbsphinx
+nbformat==5.10.4
+    # via jupyter-server
+    # via nbclient
+    # via nbconvert
+    # via nbsphinx
+nbsphinx==0.9.4
+    # via acoustic-toolbox
+    # via nbsphinx-link
+nbsphinx-link==1.3.0
+    # via acoustic-toolbox
+nest-asyncio==1.6.0
+    # via ipykernel
+notebook==7.2.1
+    # via jupyter
+notebook-shim==0.2.4
+    # via jupyterlab
+    # via notebook
+numpy==1.26.4
     # via acoustic-toolbox
     # via contourpy
     # via matplotlib
     # via pandas
     # via scipy
+overrides==7.7.0
+    # via jupyter-server
 packaging==24.1
+    # via ipykernel
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
     # via matplotlib
+    # via nbconvert
+    # via qtconsole
+    # via qtpy
+    # via sphinx
 pandas==2.2.2
     # via acoustic-toolbox
+pandocfilters==1.5.1
+    # via nbconvert
+parso==0.8.4
+    # via jedi
+pexpect==4.9.0
+    # via ipython
 pillow==10.4.0
     # via matplotlib
+platformdirs==4.2.2
+    # via jupyter-core
+prometheus-client==0.20.0
+    # via jupyter-server
+prompt-toolkit==3.0.47
+    # via ipython
+    # via jupyter-console
+psutil==6.0.0
+    # via ipykernel
+ptyprocess==0.7.0
+    # via pexpect
+    # via terminado
+pure-eval==0.2.3
+    # via stack-data
 pycparser==2.22
     # via cffi
+pygments==2.18.0
+    # via ipython
+    # via jupyter-console
+    # via nbconvert
+    # via qtconsole
+    # via sphinx
 pyparsing==3.1.2
     # via matplotlib
 pysoundfile==0.9.0.post1
     # via acoustic-toolbox
 python-dateutil==2.9.0.post0
+    # via arrow
+    # via jupyter-client
     # via matplotlib
     # via pandas
+python-json-logger==2.0.7
+    # via jupyter-events
 pytz==2024.1
     # via pandas
+pyyaml==6.0.1
+    # via jupyter-events
+pyzmq==26.0.3
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-server
+    # via qtconsole
+qtconsole==5.5.2
+    # via jupyter
+qtpy==2.4.1
+    # via qtconsole
+referencing==0.35.1
+    # via jsonschema
+    # via jsonschema-specifications
+    # via jupyter-events
+requests==2.32.3
+    # via jupyterlab-server
+    # via sphinx
+rfc3339-validator==0.1.4
+    # via jsonschema
+    # via jupyter-events
+rfc3986-validator==0.1.1
+    # via jsonschema
+    # via jupyter-events
+rpds-py==0.19.1
+    # via jsonschema
+    # via referencing
 scipy==1.14.0
     # via acoustic-toolbox
+send2trash==1.8.3
+    # via jupyter-server
+setuptools==72.1.0
+    # via jupyterlab
 six==1.16.0
     # via acoustic-toolbox
+    # via asttokens
+    # via bleach
     # via python-dateutil
+    # via rfc3339-validator
+sniffio==1.3.1
+    # via anyio
+    # via httpx
+snowballstemmer==2.2.0
+    # via sphinx
+soupsieve==2.5
+    # via beautifulsoup4
+sphinx==7.3.7
+    # via acoustic-toolbox
+    # via nbsphinx
+    # via nbsphinx-link
+    # via sphinx-rtd-theme
+    # via sphinxcontrib-jquery
+sphinx-rtd-theme==1.3.0rc1
+    # via acoustic-toolbox
+sphinxcontrib-applehelp==2.0.0
+    # via sphinx
+sphinxcontrib-devhelp==2.0.0
+    # via sphinx
+sphinxcontrib-htmlhelp==2.1.0
+    # via sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==2.0.0
+    # via sphinx
+sphinxcontrib-serializinghtml==2.0.0
+    # via sphinx
+stack-data==0.6.3
+    # via ipython
 tabulate==0.9.0
     # via acoustic-toolbox
+terminado==0.18.1
+    # via jupyter-server
+    # via jupyter-server-terminals
+tinycss2==1.3.0
+    # via nbconvert
+tomli==2.0.1
+    # via jupyterlab
+    # via sphinx
+tornado==6.4.1
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-server
+    # via jupyterlab
+    # via notebook
+    # via terminado
+traitlets==5.14.3
+    # via comm
+    # via ipykernel
+    # via ipython
+    # via ipywidgets
+    # via jupyter-client
+    # via jupyter-console
+    # via jupyter-core
+    # via jupyter-events
+    # via jupyter-server
+    # via jupyterlab
+    # via matplotlib-inline
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+    # via nbsphinx
+    # via qtconsole
+types-python-dateutil==2.9.0.20240316
+    # via arrow
+typing-extensions==4.12.2
+    # via anyio
+    # via async-lru
+    # via ipython
 tzdata==2024.1
     # via pandas
+uri-template==1.3.0
+    # via jsonschema
+urllib3==2.2.2
+    # via requests
+wcwidth==0.2.13
+    # via prompt-toolkit
+webcolors==24.6.0
+    # via jsonschema
+webencodings==0.5.1
+    # via bleach
+    # via tinycss2
+websocket-client==1.8.0
+    # via jupyter-server
+widgetsnbextension==4.0.11
+    # via ipywidgets


### PR DESCRIPTION
numpy v2.0 is still quite new and some packages may not be compatible with it yet. For instance, Soundscapy currently restricts to numpy<2. We can use numpy >=v1.23.5 instead and maintain compatibility with the rest of the dependencies. 
